### PR TITLE
Optimize the maintenance of `cexAddresses` array

### DIFF
--- a/contracts/src/Summa.sol
+++ b/contracts/src/Summa.sol
@@ -41,12 +41,9 @@ contract Summa is Ownable {
             "CEX addresses and signatures count mismatch"
         );
 
-        for (uint i = 0; i < _cexAddresses.length; i++) {
-            if (i >= cexAddresses.length) {
-                cexAddresses.push(_cexAddresses[i]);
-            } else if (_cexAddresses[i] != cexAddresses[i]) {
-                cexAddresses[i] = _cexAddresses[i];
-            }
+        address[] memory newCexAddresses = new address[](_cexAddresses.length);
+
+        for (uint i = 0; i < _cexAddresses.length; ++i) {
             address recoveredPubKey = keccak256(abi.encode(message))
                 .toEthSignedMessageHash()
                 .recover(cexSignatures[i]);
@@ -54,15 +51,10 @@ contract Summa is Ownable {
                 _cexAddresses[i] == recoveredPubKey,
                 "Invalid signer for ETH address"
             );
+            newCexAddresses[i] = _cexAddresses[i];
         }
 
-        // Since we're always rewriting the old array with the new values, we need to make sure that we remove any leftovers if the new set of addresses is smaller than the old one
-        // TODO - explore some gas-efficient ways of maintaining this array
-        if (_cexAddresses.length < cexAddresses.length) {
-            for (uint i = _cexAddresses.length; i < cexAddresses.length; i++) {
-                cexAddresses.pop();
-            }
-        }
+        cexAddresses = newCexAddresses;
 
         emit ExchangeAddressesSubmitted(cexAddresses);
     }

--- a/contracts/src/Summa.sol
+++ b/contracts/src/Summa.sol
@@ -41,8 +41,6 @@ contract Summa is Ownable {
             "CEX addresses and signatures count mismatch"
         );
 
-        address[] memory newCexAddresses = new address[](_cexAddresses.length);
-
         for (uint i = 0; i < _cexAddresses.length; ++i) {
             address recoveredPubKey = keccak256(abi.encode(message))
                 .toEthSignedMessageHash()
@@ -51,10 +49,9 @@ contract Summa is Ownable {
                 _cexAddresses[i] == recoveredPubKey,
                 "Invalid signer for ETH address"
             );
-            newCexAddresses[i] = _cexAddresses[i];
         }
 
-        cexAddresses = newCexAddresses;
+        cexAddresses = _cexAddresses;
 
         emit ExchangeAddressesSubmitted(cexAddresses);
     }


### PR DESCRIPTION
As mentioned here;
https://github.com/summa-dev/summa-solvency/blob/ded7155c585eabef653bfc84ec26ca10a6acd632/contracts/src/Summa.sol#L60

The existing approach of maintaining the `cexAddresses` array can be optimized for gas efficiency. The current method removes excess elements from the `cexAddresses` array one-by-one, which could be costly in terms of gas when the array is significantly larger than `_cexAddresses`.

So an alternative approach can be to create a new array with the correct size and replace the old array with it as a whole. 
Or even just replace the old array with the input `_cexAddresses` array directly.