### PR TITLE
fix: `swap_constraint` bug

### DIFF
--- a/zk_prover/src/chips/merkle_sum_tree.rs
+++ b/zk_prover/src/chips/merkle_sum_tree.rs
@@ -20,7 +20,8 @@ pub struct MerkleSumTreeConfig {
 /// Chip that performs various constraints related to a Merkle Sum Tree data structure such as:
 ///
 /// * `s * swap_bit * (1 - swap_bit) = 0` (if `bool_and_swap_selector` is toggled). It basically enforces that swap_bit is either a 0 or 1.
-/// * `s * swap_bit * ((elelment_l_next - elelment_l_cur) - (elelment_r_cur - elelment_r_next))`. Enforces that if the swap_bit is equal to 1, the values will be swapped on the next row (if `bool_and_swap_selector` is toggled).
+/// * `s * (swap_bit * 2 * (elelment_r_cur - elelment_l_cur)  - (elelment_l_next - elelment_l_cur) - (elelment_r_cur - elelment_r_next)) = 0`. Enforces that if the swap_bit is equal to 1, the values will be swapped on the next row (if `bool_and_swap_selector` is toggled).
+/// If the swap_bit is equal to 0, the values will remain the same on the next row (if `bool_and_swap_selector` is toggled).
 /// * `s * (left_balance + right_balance - computed_sum)`. It constraints the computed sum to be equal to the sum of the left and right balances (if `sum_selector` is toggled).
 #[derive(Debug, Clone)]
 pub struct MerkleSumTreeChip<const N_ASSETS: usize> {
@@ -59,8 +60,11 @@ impl<const N_ASSETS: usize> MerkleSumTreeChip<N_ASSETS> {
             let elelment_r_next = meta.query_advice(col_b, Rotation::next());
 
             let swap_constraint = s
-                * swap_bit
-                * ((elelment_l_next - elelment_l_cur) - (elelment_r_cur - elelment_r_next));
+                * ((swap_bit
+                    * Expression::Constant(Fp::from(2))
+                    * (elelment_r_cur.clone() - elelment_l_cur.clone())
+                    - (elelment_l_next - elelment_l_cur))
+                    - (elelment_r_cur - elelment_r_next));
 
             vec![swap_constraint]
         });

--- a/zk_prover/src/circuits/tests.rs
+++ b/zk_prover/src/circuits/tests.rs
@@ -457,6 +457,64 @@ mod test {
                     },
                     cell_values: vec![(((Any::advice(), 2).into(), 0).into(), "0x2".to_string()),]
                 },
+                VerifyFailure::ConstraintNotSatisfied {
+                    constraint: ((4, "swap constraint").into(), 0, "").into(),
+                    location: FailureLocation::InRegion {
+                        region: (3, "assign nodes hashes per merkle tree level").into(),
+                        offset: 0
+                    },
+                    cell_values: vec![
+                        (
+                            ((Any::advice(), 0).into(), 0).into(),
+                            "0xe113acd03b98f0bab0ef6f577245d5d008cbcc19ef2dab3608aa4f37f72a407"
+                                .to_string()
+                        ),
+                        (
+                            ((Any::advice(), 0).into(), 1).into(),
+                            "0x17ef9d8ee0e2c8470814651413b71009a607a020214f749687384a7b7a7eb67a"
+                                .to_string()
+                        ),
+                        (
+                            ((Any::advice(), 1).into(), 0).into(),
+                            "0x17ef9d8ee0e2c8470814651413b71009a607a020214f749687384a7b7a7eb67a"
+                                .to_string()
+                        ),
+                        (
+                            ((Any::advice(), 1).into(), 1).into(),
+                            "0xe113acd03b98f0bab0ef6f577245d5d008cbcc19ef2dab3608aa4f37f72a407"
+                                .to_string()
+                        ),
+                        (((Any::advice(), 2).into(), 0).into(), "0x2".to_string()),
+                    ]
+                },
+                VerifyFailure::ConstraintNotSatisfied {
+                    constraint: ((4, "swap constraint").into(), 0, "").into(),
+                    location: FailureLocation::InRegion {
+                        region: (4, "assign nodes balances per asset").into(),
+                        offset: 0
+                    },
+                    cell_values: vec![
+                        (((Any::advice(), 0).into(), 0).into(), "0x2e70".to_string()),
+                        (((Any::advice(), 0).into(), 1).into(), "0x108ef".to_string()),
+                        (((Any::advice(), 1).into(), 0).into(), "0x108ef".to_string()),
+                        (((Any::advice(), 1).into(), 1).into(), "0x2e70".to_string()),
+                        (((Any::advice(), 2).into(), 0).into(), "0x2".to_string()),
+                    ]
+                },
+                VerifyFailure::ConstraintNotSatisfied {
+                    constraint: ((4, "swap constraint").into(), 0, "").into(),
+                    location: FailureLocation::InRegion {
+                        region: (7, "assign nodes balances per asset").into(),
+                        offset: 0
+                    },
+                    cell_values: vec![
+                        (((Any::advice(), 0).into(), 0).into(), "0xa0cb".to_string()),
+                        (((Any::advice(), 0).into(), 1).into(), "0x48db".to_string()),
+                        (((Any::advice(), 1).into(), 0).into(), "0x48db".to_string()),
+                        (((Any::advice(), 1).into(), 1).into(), "0xa0cb".to_string()),
+                        (((Any::advice(), 2).into(), 0).into(), "0x2".to_string()),
+                    ]
+                },
                 VerifyFailure::Permutation {
                     column: (Any::advice(), 0).into(),
                     location: FailureLocation::InRegion {


### PR DESCRIPTION
This PR fixes a bug in our current `swap_constraint`.

In particular the current swap_constraint `s * swap_bit * ((elelment_l_next - elelment_l_cur) - (elelment_r_cur - elelment_r_next))` correctly check that the swapping is performed correctly **only** in the case in which `swap_bit` is equal to 1 and therefore the swapping needs to be performed. 

In the case in which `swap_bit` is equal to 0, meaning that the swapping between row(cur) and row(next) doesn't need to be performed, the polynomial constraint will always be equal to 0, therefore without checking that the values were carried from row(cur) to row(next) correctly without performing any swap.

The new polynomial constraint solves this issue