### PR TITLE
Separated signer from core components.

### DIFF
--- a/backend/examples/summa_solvency_flow.rs
+++ b/backend/examples/summa_solvency_flow.rs
@@ -20,7 +20,7 @@ const USER_INDEX: usize = 0;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize test environment without `address_ownership` instance from `initialize_test_env` function.
-    let (anvil, _, _, _, summa_contract) = initialize_test_env().await;
+    let (anvil, _, _, _, summa_contract) = initialize_test_env(None).await;
 
     // 1. Submit ownership proof
     //

--- a/backend/examples/summa_solvency_flow.rs
+++ b/backend/examples/summa_solvency_flow.rs
@@ -1,7 +1,7 @@
 #![feature(generic_const_exprs)]
-use std::{error::Error, fs::File, io::BufReader, io::Write, sync::Arc};
+use std::{error::Error, fs::File, io::BufReader, io::Write};
 
-use ethers::{providers::Provider, types::U256};
+use ethers::types::U256;
 use serde_json::{from_reader, to_string_pretty};
 
 use summa_backend::{
@@ -27,18 +27,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Each CEX prepares its own `signature` CSV file.
     let signature_csv_path = "src/apis/csv/signatures.csv";
 
-    // The signer would be using `provider` that shared with `address_ownership` and `round` instances.
-    let provider = Arc::new(Provider::try_from(anvil.endpoint().as_str())?);
-
+    // The signer instance would be shared with `address_ownership` and `round` instances
+    //
     // Using AddressInput::Address to directly provide the summa_contract's address.
     // For deployed contracts, if the address is stored in a config file,
     // you can alternatively use AddressInput::Path to specify the file's path.
     let signer = SummaSigner::new(
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-        anvil.chain_id(),
-        provider,
+        anvil.endpoint().as_str(),
         AddressInput::Address(summa_contract.address()),
-    );
+    )
+    .await?;
 
     let mut address_ownership_client = AddressOwnership::new(&signer, signature_csv_path).unwrap();
 
@@ -58,7 +57,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let params_path = "ptau/hermez-raw-11";
 
     // Using the `round` instance, the solvency proof is dispatched to the Summa contract with the `dispatch_solvency_proof` method.
-    let mut round = Round::<4, 2, 14>::new(&signer, entry_csv, asset_csv, params_path, 1).unwrap();
+    let timestamp = 1u64;
+    let mut round =
+        Round::<4, 2, 14>::new(&signer, entry_csv, asset_csv, params_path, timestamp).unwrap();
 
     // Sends the solvency proof, which should ideally complete without errors.
     round.dispatch_solvency_proof().await?;

--- a/backend/src/apis/address_ownership.rs
+++ b/backend/src/apis/address_ownership.rs
@@ -1,29 +1,23 @@
-use crate::contracts::{
-    generated::summa_contract::AddressOwnershipProof,
-    signer::{AddressInput, SummaSigner},
-};
+use crate::contracts::{generated::summa_contract::AddressOwnershipProof, signer::SummaSigner};
 use std::{error::Error, result::Result};
 
 use super::csv_parser::parse_signature_csv;
 
-pub struct AddressOwnership {
+pub struct AddressOwnership<'a> {
     address_ownership_proofs: Vec<AddressOwnershipProof>,
-    signer: SummaSigner,
+    signer: &'a SummaSigner,
 }
 
-impl AddressOwnership {
-    pub fn new(
-        signer_key: &str,
-        chain_id: u64,
-        rpc_url: &str,
-        summa_address_input: AddressInput,
+impl AddressOwnership<'_> {
+    pub fn new<'a>(
+        signer: &'a SummaSigner,
         signature_csv_path: &str,
-    ) -> Result<AddressOwnership, Box<dyn Error>> {
+    ) -> Result<AddressOwnership<'a>, Box<dyn Error>> {
         let address_ownership_proofs = parse_signature_csv(signature_csv_path)?;
 
         Ok(AddressOwnership {
             address_ownership_proofs,
-            signer: SummaSigner::new(signer_key, chain_id, rpc_url, summa_address_input),
+            signer,
         })
     }
 

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -61,7 +61,7 @@ pub async fn initialize_test_env(
             .await;
     }
 
-    // TODO: Mock ERC20 contract deployment following the attributes of `summa_contract`
+    // Mock ERC20 contract deployment
     // Creating a factory to deploy a mock ERC20 contract
     let factory = ContractFactory::new(
         MOCKERC20_ABI.to_owned(),
@@ -211,7 +211,7 @@ mod test {
             round_two.dispatch_solvency_proof()
         );
 
-        // Make sure the block has been mined at least 2 blocks
+        // Check two blocks has been mined
         for _ in 0..5 {
             sleep(Duration::from_millis(500)).await;
             let updated_block_number = outer_provider.get_block_number().await?;


### PR DESCRIPTION
- `AddressOwnership` and `Round` now require a `Signer` for initialization. and they use same signer instance.
- The `Signer` has a mutex lock for preventing nonce collision.
- Added test case that submit two solvency proofs at the same time.