### PR TITLE
Implement a self-hosted runner dedicated to the Rust workflow

### DIFF
--- a/.github/scripts/wakeup.sh
+++ b/.github/scripts/wakeup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+runner="i-0e04845bff4576909"
+
+while true; do
+  runner_status=$(aws ec2 describe-instances --instance-ids $runner --query "Reservations[*].Instances[*].State.[Name]" --output text)
+  if [ $runner_status = "stopped" ]; then
+    aws ec2 start-instances --instance-ids $runner
+    break
+  elif [ $runner_status = "running" ]; then
+    break
+  else
+    sleep 5
+  fi
+done
+
+exit 0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,15 +6,42 @@ on:
   pull_request:
     branches: ["*"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  wakeup:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::490752553772:role/summa-solvency-ec2-slc
+          role-duration-seconds: 900
+          aws-region: us-west-2
+
+      - name: Wakeup runner
+        run: .github/scripts/wakeup.sh 
+
+  build:
+    runs-on: [summa-solvency-runner]
+    needs: [wakeup]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Environment
+        run: echo "PATH=/home/ubuntu/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" >> "$GITHUB_ENV"
 
       - name: Install solc
         run: (hash svm 2>/dev/null || cargo install --version 0.2.23 svm-rs) && svm install 0.8.20 && solc --version


### PR DESCRIPTION
**Info**
With this PR, a new self-hosted runner is introduced for the Rust workflow, which is located in AWS.

**Changes**
- rust workflow was modified to run on the self-hosted runner. A new job was created as well, that wakes up the runner and uses GH' s OIDC provider to get short-lived AWS credentials required for the specific actions.
- wakeup.sh script was created, to launch the specific runner.

The runner in question, is a C6a class instance with 48vCPUs and 96GB of RAM.
Total execution time was decreased from ~15' -> 4'.