### PR TITLE
Modified new method in MerkleSumTree in mst

### DIFF
--- a/backend/examples/summa_solvency_flow.rs
+++ b/backend/examples/summa_solvency_flow.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize the `Round` instance to submit the liability commitment.
     let params_path = "ptau/hermez-raw-11";
     let entry_csv = "../csv/entry_16.csv";
-    let mst = MerkleSumTree::new(entry_csv).unwrap();
+    let mst = MerkleSumTree::from_csv(entry_csv).unwrap();
 
     // Using the `round` instance, the commitment is dispatched to the Summa contract with the `dispatch_commitment` method.
     let timestamp = 1u64;

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -158,7 +158,7 @@ mod test {
 
         let params_path = "ptau/hermez-raw-11";
         let entry_csv = "../csv/entry_16.csv";
-        let mst = MerkleSumTree::new(entry_csv).unwrap();
+        let mst = MerkleSumTree::from_csv(entry_csv).unwrap();
 
         let mut round_one =
             Round::<4, 2, 14>::new(&signer, Box::new(mst.clone()), params_path, 1).unwrap();
@@ -238,7 +238,7 @@ mod test {
         let params_path = "ptau/hermez-raw-11";
         let entry_csv = "../csv/entry_16.csv";
 
-        let mst = MerkleSumTree::new(entry_csv).unwrap();
+        let mst = MerkleSumTree::from_csv(entry_csv).unwrap();
         let mut round = Round::<4, 2, 14>::new(&signer, Box::new(mst), params_path, 1).unwrap();
 
         let mut liability_commitment_logs = summa_contract

--- a/zk_prover/benches/full_solvency_flow.rs
+++ b/zk_prover/benches/full_solvency_flow.rs
@@ -29,7 +29,7 @@ fn build_mstree(_c: &mut Criterion) {
 
     criterion.bench_function(&bench_name, |b| {
         b.iter(|| {
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new(&csv_file).unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv(&csv_file).unwrap();
         })
     });
 }
@@ -49,7 +49,7 @@ fn build_sorted_mstree(_c: &mut Criterion) {
 
     criterion.bench_function(&bench_name, |b| {
         b.iter(|| {
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new_sorted(&csv_file).unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv_sorted(&csv_file).unwrap();
         })
     });
 }
@@ -102,7 +102,7 @@ fn generate_zk_proof_mst_inclusion_circuit(_c: &mut Criterion) {
         PATH_NAME, PATH_NAME, LEVELS
     );
 
-    let merkle_sum_tree = MerkleSumTree::<N_CURRENCIES, N_BYTES>::new(&csv_file).unwrap();
+    let merkle_sum_tree = MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv(&csv_file).unwrap();
 
     // Only now we can instantiate the circuit with the actual inputs
 
@@ -135,7 +135,7 @@ fn verify_zk_proof_mst_inclusion_circuit(_c: &mut Criterion) {
         PATH_NAME, PATH_NAME, LEVELS
     );
 
-    let merkle_sum_tree = MerkleSumTree::<N_CURRENCIES, N_BYTES>::new(&csv_file).unwrap();
+    let merkle_sum_tree = MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv(&csv_file).unwrap();
 
     // Only now we can instantiate the circuit with the actual inputs
 

--- a/zk_prover/examples/gen_commitment.rs
+++ b/zk_prover/examples/gen_commitment.rs
@@ -13,7 +13,7 @@ const N_BYTES: usize = 14;
 
 fn main() {
     let merkle_sum_tree =
-        MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+        MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
     let root = merkle_sum_tree.root();
 

--- a/zk_prover/examples/gen_inclusion_verifier.rs
+++ b/zk_prover/examples/gen_inclusion_verifier.rs
@@ -52,7 +52,7 @@ fn main() {
     write_verifier_sol_from_yul(yul_output_path, sol_output_path).unwrap();
 
     let merkle_sum_tree =
-        MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+        MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
     // In order to generate a proof for testing purpose we create the circuit using the init() method
     // which takes as input the merkle sum tree and the index of the leaf we are generating the proof for.

--- a/zk_prover/src/circuits/tests.rs
+++ b/zk_prover/src/circuits/tests.rs
@@ -25,7 +25,7 @@ mod test {
     #[test]
     fn test_valid_merkle_sum_tree() {
         let merkle_sum_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         for user_index in 0..16 {
             // get proof for entry ˆuser_indexˆ
@@ -55,7 +55,7 @@ mod test {
         let (params, pk, vk) = generate_setup_artifacts(K, None, circuit).unwrap();
 
         let merkle_sum_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         let user_index = 0;
 
@@ -91,7 +91,7 @@ mod test {
     #[test]
     fn test_invalid_root_hash() {
         let merkle_sum_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
         let user_index = 0;
 
         let merkle_proof = merkle_sum_tree.generate_proof(user_index).unwrap();
@@ -130,7 +130,7 @@ mod test {
         let (params, pk, vk) = generate_setup_artifacts(K, None, circuit).unwrap();
 
         let merkle_sum_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         let user_index = 0;
 
@@ -158,7 +158,7 @@ mod test {
     #[test]
     fn test_invalid_entry_balance_as_witness() {
         let merkle_sum_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         let user_index = 0;
 
@@ -233,7 +233,7 @@ mod test {
     #[test]
     fn test_invalid_leaf_hash_as_instance() {
         let merkle_sum_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         let user_index = 0;
 
@@ -270,7 +270,7 @@ mod test {
     #[test]
     fn test_non_binary_index() {
         let merkle_sum_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         let user_index = 0;
 
@@ -434,7 +434,7 @@ mod test {
     #[test]
     fn test_swapping_index() {
         let merkle_sum_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         let user_index = 0;
 
@@ -474,7 +474,7 @@ mod test {
         use plotters::prelude::*;
 
         let merkle_sum_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         let user_index = 0;
 

--- a/zk_prover/src/merkle_sum_tree/mst.rs
+++ b/zk_prover/src/merkle_sum_tree/mst.rs
@@ -65,17 +65,40 @@ pub struct Cryptocurrency {
 }
 
 impl<const N_CURRENCIES: usize, const N_BYTES: usize> MerkleSumTree<N_CURRENCIES, N_BYTES> {
+    pub fn new(
+        root: Node<N_CURRENCIES>,
+        nodes: Vec<Vec<Node<N_CURRENCIES>>>,
+        depth: usize,
+        entries: Vec<Entry<N_CURRENCIES>>,
+        cryptocurrencies: Vec<Cryptocurrency>,
+        is_sorted: bool,
+    ) -> Result<Self, Box<dyn std::error::Error>>
+    where
+        [usize; N_CURRENCIES + 1]: Sized,
+        [usize; N_CURRENCIES + 2]: Sized,
+    {
+        Ok(MerkleSumTree::<N_CURRENCIES, N_BYTES> {
+            root,
+            nodes,
+            depth,
+            entries,
+            cryptocurrencies,
+            is_sorted,
+        })
+    }
+
     /// Builds a Merkle Sum Tree from a CSV file stored at `path`. The CSV file must be formatted as follows:
     ///
     /// `username,balance_<cryptocurrency>_<chain>,balance_<cryptocurrency>_<chain>,...`
     ///
     /// `dxGaEAii,11888,41163`
-    pub fn new(path: &str) -> Result<Self, Box<dyn std::error::Error>>
+    pub fn from_csv(path: &str) -> Result<Self, Box<dyn std::error::Error>>
     where
         [usize; N_CURRENCIES + 1]: Sized,
         [usize; N_CURRENCIES + 2]: Sized,
     {
-        let (cryptocurrencies, entries) = parse_csv_to_entries::<&str, N_CURRENCIES, N_BYTES>(path)?;
+        let (cryptocurrencies, entries) =
+            parse_csv_to_entries::<&str, N_CURRENCIES, N_BYTES>(path)?;
         Self::from_entries(entries, cryptocurrencies, false)
     }
 
@@ -84,7 +107,7 @@ impl<const N_CURRENCIES: usize, const N_BYTES: usize> MerkleSumTree<N_CURRENCIES
     /// `username,balance_<cryptocurrency>_<chain>,balance_<cryptocurrency>_<chain>,...`
     ///
     /// `dxGaEAii,11888,41163`
-    pub fn new_sorted(path: &str) -> Result<Self, Box<dyn std::error::Error>>
+    pub fn from_csv_sorted(path: &str) -> Result<Self, Box<dyn std::error::Error>>
     where
         [usize; N_CURRENCIES + 1]: Sized,
         [usize; N_CURRENCIES + 2]: Sized,

--- a/zk_prover/src/merkle_sum_tree/tests.rs
+++ b/zk_prover/src/merkle_sum_tree/tests.rs
@@ -13,7 +13,7 @@ mod test {
     fn test_mst() {
         // create new merkle tree
         let merkle_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         // get root
         let root = merkle_tree.root();
@@ -33,7 +33,7 @@ mod test {
 
         // Should generate different root hashes when changing the entry order
         let merkle_tree_2 =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16_switched_order.csv")
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16_switched_order.csv")
                 .unwrap();
         assert_ne!(root.hash, merkle_tree_2.root().hash);
 
@@ -69,13 +69,14 @@ mod test {
     #[test]
     fn test_update_mst_leaf() {
         let merkle_tree_1 =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         let root_hash_1 = merkle_tree_1.root().hash;
 
         //Create the second tree with the 7th entry different from the the first tree
         let mut merkle_tree_2 =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16_modified.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16_modified.csv")
+                .unwrap();
 
         let root_hash_2 = merkle_tree_2.root().hash;
         assert!(root_hash_1 != root_hash_2);
@@ -94,7 +95,7 @@ mod test {
     #[test]
     fn test_update_invalid_mst_leaf() {
         let mut merkle_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new_sorted("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv_sorted("../csv/entry_16.csv").unwrap();
 
         let new_root = merkle_tree.update_leaf(
             "non_existing_user", //This username is not present in the tree
@@ -109,13 +110,13 @@ mod test {
     #[test]
     fn test_sorted_mst() {
         let merkle_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         let old_root_balances = merkle_tree.root().balances;
         let old_root_hash = merkle_tree.root().hash;
 
         let sorted_merkle_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new_sorted("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv_sorted("../csv/entry_16.csv").unwrap();
 
         let new_root_balances = sorted_merkle_tree.root().balances;
         let new_root_hash = sorted_merkle_tree.root().hash;
@@ -129,7 +130,8 @@ mod test {
     // Passing a csv file with a single entry that has a balance that is not in the expected range will fail
     #[test]
     fn test_mst_overflow_1() {
-        let result = MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16_overflow.csv");
+        let result =
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16_overflow.csv");
 
         if let Err(e) = result {
             assert_eq!(
@@ -142,7 +144,8 @@ mod test {
     #[test]
     // Passing a csv file in which the entries have a balance in the range, but while summing it generates a ndoe in which the balance is not in the expected range will fail
     fn test_mst_overflow_2() {
-        let result = MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16_overflow_2.csv");
+        let result =
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16_overflow_2.csv");
 
         if let Err(e) = result {
             assert_eq!(
@@ -155,7 +158,8 @@ mod test {
     // Passing a csv file with a single entry that has a balance that is the maximum that can fit in the expected range will not fail
     #[test]
     fn test_mst_no_overflow() {
-        let result = MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16_no_overflow.csv");
+        let result =
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16_no_overflow.csv");
         assert!(result.is_ok());
     }
 
@@ -184,7 +188,7 @@ mod test {
     #[test]
     fn get_middle_node_hash_preimage() {
         let merkle_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         let depth = *merkle_tree.depth();
 
@@ -213,7 +217,7 @@ mod test {
     #[test]
     fn get_leaf_node_hash_preimage() {
         let merkle_tree =
-            MerkleSumTree::<N_CURRENCIES, N_BYTES>::new("../csv/entry_16.csv").unwrap();
+            MerkleSumTree::<N_CURRENCIES, N_BYTES>::from_csv("../csv/entry_16.csv").unwrap();
 
         // Generate a random number between 0 and 15
         let mut rng = rand::thread_rng();


### PR DESCRIPTION
The current `new` method in `MerkleSumTree` requires a `csv_path` parameter. However, for the Summa Aggregation project, there's a need for an actual `new` method that aligns with the implementation shown here: [Summa Aggregation - json_mst](https://github.com/summa-dev/summa-aggregation/blob/4a4d71b619251382feb2e85b7992835221ecc2d6/src/json_mst.rs#L116-L121).

```Rust
MerkleSumTree::<N_ASSETS, N_BYTES> {
    root,
    nodes,
    depth: self.depth,
    entries,
    is_sorted: self.is_sorted,
}
```