### PR TITLE
Remove unused return variables

### DIFF
--- a/zk_prover/src/chips/merkle_sum_tree.rs
+++ b/zk_prover/src/chips/merkle_sum_tree.rs
@@ -192,14 +192,7 @@ impl<const N_CURRENCIES: usize> MerkleSumTreeChip<N_CURRENCIES> {
         current_balance: &AssignedCell<Fp, Fp>,
         element_balance: &AssignedCell<Fp, Fp>,
         swap_bit_assigned: &AssignedCell<Fp, Fp>,
-    ) -> Result<
-        (
-            AssignedCell<Fp, Fp>,
-            AssignedCell<Fp, Fp>,
-            AssignedCell<Fp, Fp>,
-        ),
-        Error,
-    > {
+    ) -> Result<AssignedCell<Fp, Fp>, Error> {
         layouter.assign_region(
             || "assign nodes balances per currency",
             |mut region| {
@@ -267,7 +260,7 @@ impl<const N_CURRENCIES: usize> MerkleSumTreeChip<N_CURRENCIES> {
                 let sum_cell =
                     region.assign_advice(|| "sum of balances", self.config.advice[2], 1, || sum)?;
 
-                Ok((left_currency_balance, right_currency_balance, sum_cell))
+                Ok(sum_cell)
             },
         )
     }

--- a/zk_prover/src/circuits/merkle_sum_tree.rs
+++ b/zk_prover/src/circuits/merkle_sum_tree.rs
@@ -456,27 +456,22 @@ where
                 )?;
 
             let mut next_balances = vec![];
-            let mut left_balances = vec![];
-            let mut right_balances = vec![];
 
             // For every level, perform the swap of the balances (between `current_balances` and `sibling_balances`) according to the swap bit
             for currency in 0..N_CURRENCIES {
-                let (left_balance, right_balance, next_balance) = merkle_sum_tree_chip
-                    .swap_balances_per_level(
-                        layouter.namespace(|| {
-                            format!(
-                                "{}: currency {}: assign nodes balance",
-                                namespace_prefix, currency
-                            )
-                        }),
-                        &current_balances[currency],
-                        &sibling_balances[currency],
-                        &swap_bit_level,
-                    )?;
+                let next_balance = merkle_sum_tree_chip.swap_balances_per_level(
+                    layouter.namespace(|| {
+                        format!(
+                            "{}: currency {}: assign nodes balance",
+                            namespace_prefix, currency
+                        )
+                    }),
+                    &current_balances[currency],
+                    &sibling_balances[currency],
+                    &swap_bit_level,
+                )?;
 
                 next_balances.push(next_balance);
-                left_balances.push(left_balance);
-                right_balances.push(right_balance);
             }
 
             // create an hash_input array of length N_CURRENCIES + 2 that contains the next balances, the left hash and the right hash


### PR DESCRIPTION
The variables are actually not used after the assignment.