### PR TITLE
Manual trigger to start benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,10 +1,6 @@
 name: Benchmark
 
 on:
-  push:
-    branches: ["*"]
-  pull_request:
-    branches: ["*"]  
   workflow_dispatch:
     inputs:
       run_benchmark:
@@ -18,6 +14,7 @@ env:
 jobs:
   wakeup:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_benchmark == 'yes' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,54 @@
+name: Benchmark
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]  
+  workflow_dispatch:
+    inputs:
+      run_benchmark:
+        description: 'Run benchmark tests (yes/no)'
+        required: true
+        default: 'no'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  wakeup:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::490752553772:role/summa-solvency-ec2-slc
+          role-duration-seconds: 900
+          aws-region: us-west-2
+
+      - name: Wakeup runner
+        run: .github/scripts/wakeup.sh 
+
+  benchmark:
+    runs-on: [summa-solvency-runner]
+    needs: [wakeup]
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_benchmark == 'yes' }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run Benchmark
+        run: |
+          cd zk_prover
+          cargo bench
+
+      - name: Upload Benchmark Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: benchmark-results
+          path: zk_prover/target/criterion


### PR DESCRIPTION
We can start benchmark on our self-host runner, which is running for testing.

Following like this; Actions tab -> Benchmark workflow -> "Run workflow" 
![image](https://github.com/summa-dev/summa-solvency/assets/10276359/bf271dd6-2b2e-480f-a181-760bfb8260ab)

The results of benchmark stored as artifacts like below:
<img width="600px" src="https://github.com/summa-dev/summa-solvency/assets/10276359/c383ab45-a8ab-4a61-a277-75d30365278f"></img>
It's located each benchmark job.