### PR TITLE
Minor fixes to V2

### DIFF
--- a/kzg_prover/src/chips/range/range_check.rs
+++ b/kzg_prover/src/chips/range/range_check.rs
@@ -132,7 +132,7 @@ impl RangeCheckU64Chip {
         // Perform the assignment of the truncated right-shifted values to zs columns.
         for (i, k) in ks.iter().enumerate() {
             let zs_next = {
-                let k = k.map(|byte| Fp::from(byte as u64));
+                let k = k.map(|byte| Fp::from(u64::from(byte)));
                 let zs_next_val = (z.value().copied() - k) * two_pow_sixteen_inv;
                 region.assign_advice(
                     || format!("zs_{:?}", i),

--- a/kzg_prover/src/chips/range/tests.rs
+++ b/kzg_prover/src/chips/range/tests.rs
@@ -124,7 +124,7 @@ impl Circuit<Fp> for TestCircuit {
 
         let zs = [(); 4].map(|_| meta.advice_column());
 
-        for column in zs.iter() {
+        for column in &zs {
             meta.enable_equality(*column);
         }
 

--- a/kzg_prover/src/chips/range/utils.rs
+++ b/kzg_prover/src/chips/range/utils.rs
@@ -46,7 +46,7 @@ pub fn decompose_fp_to_byte_pairs(value: Fp, n: usize) -> Vec<u16> {
     // Iterate over the bytes two at a time.
     for chunk in bytes.chunks(2) {
         // Combine two adjacent bytes into a u16 (2 bytes).
-        let pair = (chunk[0] as u16) | ((chunk[1] as u16) << 8);
+        let pair = (u16::from(chunk[0])) | ((u16::from(chunk[1])) << 8);
         byte_pairs.push(pair);
     }
 

--- a/kzg_prover/src/circuits/tests.rs
+++ b/kzg_prover/src/circuits/tests.rs
@@ -53,7 +53,7 @@ mod test {
         // The Custodian generates the ZK-SNARK Halo2 proof that commits to the user entry values in advice polynomials
         // and also range-checks the user balance values
         let (zk_snark_proof, advice_polys, omega) =
-            full_prover(&params, &pk, circuit.clone(), vec![vec![]]);
+            full_prover(&params, &pk, circuit.clone(), &[vec![]]);
 
         // Both the Custodian and the Verifier know what column range are the balance columns
         // (The first column is the user IDs)
@@ -82,7 +82,7 @@ mod test {
 
         // 2. Verification phase
         // The Verifier verifies the ZK proof
-        assert!(full_verifier(&params, &vk, &zk_snark_proof, vec![vec![]]));
+        assert!(full_verifier(&params, &vk, &zk_snark_proof, &[vec![]]));
 
         // The Verifier is able to independently extract the omega from the verification key
         let omega = pk.get_vk().get_domain().get_omega();
@@ -98,7 +98,7 @@ mod test {
         let (verified, grand_sum) = verify_grand_sum_openings::<N_CURRENCIES>(
             &params,
             &zk_snark_proof,
-            grand_sums_batch_proof,
+            &grand_sums_batch_proof,
             poly_length,
             balance_column_range,
         );
@@ -147,7 +147,7 @@ mod test {
         // 1. Proving phase
         // The Custodian generates the ZK proof
         let (zk_snark_proof, advice_polys, omega) =
-            full_prover(&params, &pk, circuit.clone(), vec![vec![]]);
+            full_prover(&params, &pk, circuit.clone(), &[vec![]]);
 
         // The Custodian creates a KZG batch proof of the 4th user ID & balances inclusion
         let user_index = 3_u16;
@@ -164,7 +164,7 @@ mod test {
 
         // 2. Verification phase
         // The Verifier verifies the ZK proof
-        assert!(full_verifier(&params, &vk, &zk_snark_proof, vec![vec![]]));
+        assert!(full_verifier(&params, &vk, &zk_snark_proof, &[vec![]]));
 
         // The Verifier is able to independently extract the omega from the verification key
         let omega = pk.get_vk().get_domain().get_omega();
@@ -207,7 +207,7 @@ mod test {
         // The Custodian generates the ZK-SNARK Halo2 proof that commits to the user entry values in advice polynomials
         // and also range-checks the user balance values
         let (zk_snark_proof, advice_polys, _) =
-            full_prover(&params, &pk, circuit.clone(), vec![vec![]]);
+            full_prover(&params, &pk, circuit.clone(), &[vec![]]);
 
         // Both the Custodian and the Verifier know what column range are the balance columns
         // (The first column is the user IDs)
@@ -223,7 +223,7 @@ mod test {
 
         // 2. Verification phase
         // The Verifier verifies the ZK proof
-        assert!(full_verifier(&params, &vk, &zk_snark_proof, vec![vec![]]));
+        assert!(full_verifier(&params, &vk, &zk_snark_proof, &[vec![]]));
 
         // The Custodian communicates the (invalid) polynomial length to the Verifier
         let invalid_poly_length = u64::try_from(advice_polys.advice_polys[0].len()).unwrap() - 1;
@@ -236,7 +236,7 @@ mod test {
         let (verified, grand_sum) = verify_grand_sum_openings::<N_CURRENCIES>(
             &params,
             &zk_snark_proof,
-            grand_sums_batch_proof,
+            &grand_sums_batch_proof,
             invalid_poly_length,
             balance_column_range,
         );
@@ -337,7 +337,7 @@ mod test {
         // An empty circuit is used here to emphasize that the circuit inputs are not relevant when generating the keys.
         // Important: The dimensions of the circuit used to generate the keys must match those of the circuit used to generate the proof.
         // In this case, the dimensions are represented by the number fo users.
-        let (params, pk, vk) = generate_setup_artifacts(K, None, circuit).unwrap();
+        let (params, pk, vk) = generate_setup_artifacts(K, None, &circuit).unwrap();
 
         // Only now we can instantiate the circuit with the actual inputs
         let mut entries: Vec<Entry<N_CURRENCIES>> = vec![Entry::init_empty(); N_USERS];

--- a/kzg_prover/src/circuits/tests.rs
+++ b/kzg_prover/src/circuits/tests.rs
@@ -87,8 +87,8 @@ mod test {
         // The Verifier is able to independently extract the omega from the verification key
         let omega = pk.get_vk().get_domain().get_omega();
 
-        // The Custodian communicates the polynomial degree to the Verifier
-        let poly_degree = u64::try_from(advice_polys.advice_polys[0].len()).unwrap();
+        // The Custodian communicates the polynomial length to the Verifier
+        let poly_length = u64::try_from(advice_polys.advice_polys[0].len()).unwrap();
 
         // Both the Custodian and the Verifier know what column range are the balance columns
         let balance_column_range = 1..N_CURRENCIES + 1;
@@ -99,7 +99,7 @@ mod test {
             &params,
             &zk_snark_proof,
             grand_sums_batch_proof,
-            poly_degree,
+            poly_length,
             balance_column_range,
         );
 
@@ -187,7 +187,7 @@ mod test {
         assert!(!balances_verified);
     }
 
-    // The prover communicates an invalid polynomial degree to the verifier (smaller than the actual degree). This will result in an understated grand sum
+    // The prover communicates an invalid polynomial length to the verifier (smaller than the actual length). This will result in a different grand sum
     #[test]
     fn test_invalid_poly_degree_univariate_grand_sum_full_prover() {
         let path = "../csv/entry_16.csv";
@@ -225,8 +225,8 @@ mod test {
         // The Verifier verifies the ZK proof
         assert!(full_verifier(&params, &vk, &zk_snark_proof, vec![vec![]]));
 
-        // The Custodian communicates the (invalid) polynomial degree to the Verifier
-        let invalid_poly_degree = u64::try_from(advice_polys.advice_polys[0].len()).unwrap() - 1;
+        // The Custodian communicates the (invalid) polynomial length to the Verifier
+        let invalid_poly_length = u64::try_from(advice_polys.advice_polys[0].len()).unwrap() - 1;
 
         // Both the Custodian and the Verifier know what column range are the balance columns
         let balance_column_range = 1..N_CURRENCIES + 1;
@@ -237,11 +237,11 @@ mod test {
             &params,
             &zk_snark_proof,
             grand_sums_batch_proof,
-            invalid_poly_degree,
+            invalid_poly_length,
             balance_column_range,
         );
 
-        // The opened grand sum is smaller than the actual sum of balances extracted from the csv file
+        // The opened grand sum is not equal to the actual sum of balances extracted from the csv file
         assert!(verified);
         for i in 0..N_CURRENCIES {
             assert_ne!(csv_total[i], grand_sum[i]);

--- a/kzg_prover/src/circuits/univariate_grand_sum.rs
+++ b/kzg_prover/src/circuits/univariate_grand_sum.rs
@@ -67,12 +67,12 @@ where
         // Create an empty array of range check configs
         let mut range_check_configs = Vec::with_capacity(N_CURRENCIES);
 
-        for i in 0..N_CURRENCIES {
-            let z = balances[i];
+        for item in balances.iter().take(N_CURRENCIES) {
+            let z = *item;
             // Create 4 advice columns for each range check chip
             let zs = [(); 4].map(|_| meta.advice_column());
 
-            for column in zs.iter() {
+            for column in &zs {
                 meta.enable_equality(*column);
             }
 

--- a/kzg_prover/src/circuits/utils.rs
+++ b/kzg_prover/src/circuits/utils.rs
@@ -39,7 +39,7 @@ use crate::utils::fp_to_big_uint;
 pub fn generate_setup_artifacts<C: Circuit<Fp>>(
     k: u32,
     params_path: Option<&str>,
-    circuit: C,
+    circuit: &C,
 ) -> Result<
     (
         ParamsKZG<Bn256>,
@@ -74,8 +74,8 @@ pub fn generate_setup_artifacts<C: Circuit<Fp>>(
         }
     }
 
-    let vk = keygen_vk(&params, &circuit).expect("vk generation should not fail");
-    let pk = keygen_pk(&params, vk.clone(), &circuit).expect("pk generation should not fail");
+    let vk = keygen_vk(&params, circuit).expect("vk generation should not fail");
+    let pk = keygen_pk(&params, vk.clone(), circuit).expect("pk generation should not fail");
 
     Ok((params, pk, vk))
 }
@@ -85,7 +85,7 @@ pub fn full_prover<C: Circuit<Fp>>(
     params: &ParamsKZG<Bn256>,
     pk: &ProvingKey<G1Affine>,
     circuit: C,
-    public_inputs: Vec<Vec<Fp>>,
+    public_inputs: &[Vec<Fp>],
 ) -> (
     Vec<u8>,
     AdviceSingle<halo2_proofs::halo2curves::bn256::G1Affine, Coeff>,
@@ -182,7 +182,7 @@ pub fn open_user_points<const N_CURRENCIES: usize>(
     omega: Fp,
     user_index: u16,
 ) -> Vec<u8> {
-    let omega_raised = omega.pow_vartime([user_index as u64]);
+    let omega_raised = omega.pow_vartime([u64::from(user_index)]);
     create_opening_proof_at_challenge::<
         KZGCommitmentScheme<Bn256>,
         ProverSHPLONK<'_, Bn256>,
@@ -216,7 +216,7 @@ pub fn open_user_points<const N_CURRENCIES: usize>(
 pub fn verify_grand_sum_openings<const N_CURRENCIES: usize>(
     params: &ParamsKZG<Bn256>,
     zk_snark_proof: &[u8],
-    grand_sum_opening_batch_proof: Vec<u8>,
+    grand_sum_opening_batch_proof: &[u8],
     polynomial_length: u64,
     balance_column_range: Range<usize>,
 ) -> (bool, Vec<BigUint>) {
@@ -242,7 +242,7 @@ pub fn verify_grand_sum_openings<const N_CURRENCIES: usize>(
         N_CURRENCIES,
     >(
         params,
-        &grand_sum_opening_batch_proof,
+        grand_sum_opening_batch_proof,
         Fp::zero(),
         &advice_commitments,
     );
@@ -444,7 +444,7 @@ pub fn full_verifier(
     params: &ParamsKZG<Bn256>,
     vk: &VerifyingKey<G1Affine>,
     proof: &[u8],
-    public_inputs: Vec<Vec<Fp>>,
+    public_inputs: &[Vec<Fp>],
 ) -> bool {
     let verifier_params = params.verifier_params();
     let strategy = SingleStrategy::new(params);

--- a/kzg_prover/src/circuits/utils.rs
+++ b/kzg_prover/src/circuits/utils.rs
@@ -206,7 +206,7 @@ pub fn open_user_points<const N_CURRENCIES: usize>(
 /// * `params` - the KZG parameters
 /// * `zk_snark_proof` - the ZK-SNARK proof of the circuit whose advice columns contain the user balance polynomials
 /// * `grand_sum_opening_batch_proof` - the KZG batch proof of the grand sum polynomials
-/// * `polynomial_degree` - the degree of the polynomials
+/// * `polynomial_length` - the length of the polynomials
 /// * `balance_column_range` - the range of the advice columns that represent user balances
 ///
 /// # Returns
@@ -217,7 +217,7 @@ pub fn verify_grand_sum_openings<const N_CURRENCIES: usize>(
     params: &ParamsKZG<Bn256>,
     zk_snark_proof: &[u8],
     grand_sum_opening_batch_proof: Vec<u8>,
-    polynomial_degree: u64,
+    polynomial_length: u64,
     balance_column_range: Range<usize>,
 ) -> (bool, Vec<BigUint>) {
     let mut transcript: Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>> =
@@ -251,7 +251,7 @@ pub fn verify_grand_sum_openings<const N_CURRENCIES: usize>(
         verified,
         constant_terms
             .iter()
-            .map(|eval| fp_to_big_uint(eval * Fp::from(polynomial_degree)))
+            .map(|eval| fp_to_big_uint(eval * Fp::from(polynomial_length)))
             .collect(),
     )
 }

--- a/kzg_prover/src/cryptocurrency.rs
+++ b/kzg_prover/src/cryptocurrency.rs
@@ -7,8 +7,8 @@ pub struct Cryptocurrency {
 impl Cryptocurrency {
     pub fn init_empty() -> Self {
         Cryptocurrency {
-            name: "".to_string(),
-            chain: "".to_string(),
+            name: String::new(),
+            chain: String::new(),
         }
     }
 }

--- a/kzg_prover/src/entry.rs
+++ b/kzg_prover/src/entry.rs
@@ -26,7 +26,7 @@ impl<const N_ASSETS: usize> Entry<N_ASSETS> {
         Entry {
             username_as_big_uint: BigUint::from(0u32),
             balances: empty_balances,
-            username: "".to_string(),
+            username: String::new(),
         }
     }
 


### PR DESCRIPTION
The main update is in the variable name `poly_degree` that becomes `poly_length` according to the discussion here -> https://hackmd.io/@summa/BkglBWsDp?comment=fa174e40-82cb-464d-bba4-fd9c6dfa8019&utm_source=comment-card&utm_medium=icon

On top of that I discover a more precise cargo clippy version (https://www.reddit.com/r/learnrust/comments/13pvxzu/comment/jlbk9mg/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button) so I applied some of the changes suggested. I think this is useful to suggest when variable can be passed as reference to a function because they are not actually consumed within the function body.