### PR TITLE
Change username column to unblinded advice

### DIFF
--- a/kzg_prover/src/circuits/univariate_grand_sum.rs
+++ b/kzg_prover/src/circuits/univariate_grand_sum.rs
@@ -54,7 +54,7 @@ where
     [(); N_CURRENCIES + 1]:,
 {
     pub fn configure(meta: &mut ConstraintSystem<Fp>) -> Self {
-        let username = meta.advice_column();
+        let username = meta.unblinded_advice_column();
 
         let balances = [(); N_CURRENCIES].map(|_| meta.unblinded_advice_column());
 

--- a/kzg_prover/src/circuits/utils.rs
+++ b/kzg_prover/src/circuits/utils.rs
@@ -150,8 +150,8 @@ pub fn open_grand_sums<const N_CURRENCIES: usize>(
         Blake2bWrite<Vec<u8>, G1Affine, Challenge255<G1Affine>>,
     >(
         params,
-        &advice_polys[balance_column_range],
-        advice_blinds,
+        &advice_polys[balance_column_range.clone()],
+        &advice_blinds[balance_column_range],
         challenge,
     )
 }
@@ -190,8 +190,8 @@ pub fn open_user_points<const N_CURRENCIES: usize>(
         Blake2bWrite<Vec<u8>, G1Affine, Challenge255<G1Affine>>,
     >(
         params,
-        &advice_polys[column_range],
-        advice_blinds,
+        &advice_polys[column_range.clone()],
+        &advice_blinds[column_range],
         omega_raised,
     )
 }


### PR DESCRIPTION
As we observed in the benchmarks, there was a discrepancy between the user opening time and the grand sum opening time. I found out that the discrepancy was due to the user ID column being the regular advice column. After making it an unblinded advice column the discrepancy disappears.