### PR TITLE
Single user inclusion opening benchmark for the amortized KZG approach

### DIFF
--- a/kzg_prover/bin/gen_commitment.rs
+++ b/kzg_prover/bin/gen_commitment.rs
@@ -14,7 +14,7 @@ use serde_json::to_string_pretty;
 use std::{fs::File, io::Write};
 use summa_solvency::{
     circuits::{
-        univariate_grand_sum::UnivariateGrandSum,
+        univariate_grand_sum::{UnivariateGrandSum, UnivariateGrandSumConfig},
         utils::{full_prover, full_verifier, generate_setup_artifacts},
     },
     cryptocurrency::Cryptocurrency,
@@ -40,8 +40,11 @@ fn main() {
     parse_csv_to_entries::<&str, N_CURRENCIES>("../csv/entry_16.csv", &mut entries, &mut cryptos)
         .unwrap();
 
-    let univariate_grand_sum_circuit =
-        UnivariateGrandSum::<N_USERS, N_CURRENCIES>::init(entries.to_vec());
+    let univariate_grand_sum_circuit = UnivariateGrandSum::<
+        N_USERS,
+        N_CURRENCIES,
+        UnivariateGrandSumConfig<N_CURRENCIES, N_USERS>,
+    >::init(entries.to_vec());
 
     let (params, pk, _) = generate_setup_artifacts(
         K,

--- a/kzg_prover/bin/gen_verifiers.rs
+++ b/kzg_prover/bin/gen_verifiers.rs
@@ -1,6 +1,5 @@
 #![feature(generic_const_exprs)]
 
-use halo2_proofs::arithmetic::Field;
 use halo2_proofs::{
     halo2curves::bn256::Fr as Fp,
     poly::kzg::{
@@ -13,17 +12,16 @@ use halo2_solidity_verifier::{
     compile_solidity, encode_calldata, BatchOpenScheme::Bdfg21, Evm, Keccak256Transcript,
     SolidityGenerator,
 };
-use num_bigint::BigUint;
 use prelude::*;
 use rand::rngs::OsRng;
 use summa_solvency::{
     circuits::{
-        univariate_grand_sum::UnivariateGrandSum,
-        utils::{generate_setup_artifacts, open_grand_sums, verify_grand_sum_openings},
+        univariate_grand_sum::{UnivariateGrandSum, UnivariateGrandSumConfig},
+        utils::generate_setup_artifacts,
     },
     cryptocurrency::Cryptocurrency,
     entry::Entry,
-    utils::{big_uint_to_fp, parse_csv_to_entries},
+    utils::parse_csv_to_entries,
 };
 
 const K: u32 = 17;
@@ -32,7 +30,11 @@ const N_USERS: usize = 16;
 
 fn main() {
     // In order to generate the verifier we create the circuit using the init_empty() method, which means that the circuit is not initialized with any data.
-    let circuit = UnivariateGrandSum::<N_USERS, N_CURRENCIES>::init_empty();
+    let circuit = UnivariateGrandSum::<
+        N_USERS,
+        N_CURRENCIES,
+        UnivariateGrandSumConfig<N_CURRENCIES, N_USERS>,
+    >::init_empty();
 
     let (params, pk, _) =
         generate_setup_artifacts(K, Some("../backend/ptau/hermez-raw-17"), &circuit).unwrap();
@@ -44,8 +46,11 @@ fn main() {
     parse_csv_to_entries::<&str, N_CURRENCIES>("../csv/entry_16.csv", &mut entries, &mut cryptos)
         .unwrap();
 
-    let univariate_grand_sum_circuit =
-        UnivariateGrandSum::<N_USERS, N_CURRENCIES>::init(entries.to_vec());
+    let univariate_grand_sum_circuit = UnivariateGrandSum::<
+        N_USERS,
+        N_CURRENCIES,
+        UnivariateGrandSumConfig<N_CURRENCIES, N_USERS>,
+    >::init(entries.to_vec());
 
     // 1. Generate Snark Verifier Contract and Verification Key
     //

--- a/kzg_prover/src/circuits/utils.rs
+++ b/kzg_prover/src/circuits/utils.rs
@@ -3,10 +3,11 @@ use std::{fs::File, ops::Range};
 use ark_std::{end_timer, start_timer};
 use ethers::types::U256;
 use halo2_proofs::{
-    arithmetic::{best_fft, Field},
+    arithmetic::{best_fft, best_multiexp, parallelize, Field},
     halo2curves::{
         bn256::{Bn256, Fr as Fp, G1Affine, G1},
         ff::{PrimeField, WithSmallOrderMulGroup},
+        group::Curve,
     },
     plonk::{
         create_proof, keygen_pk, keygen_vk, verify_proof, AdviceSingle, Circuit, Error, ProvingKey,
@@ -221,33 +222,77 @@ pub fn open_user_points(
     )
 }
 
-/// Calculate all opening proofs at once for the polynomials using the amortized KZG approach
+/// Calculate h(x) for the amortized KZG algorithm as per FK23 for all advice polynomials in the range in parallel
 ///
 /// # Arguments
 ///
 /// * `advice_polys` - the advice polynomials
 /// * `params` - the KZG parameters
 /// * `column_range` - the range of the advice columns of interest
+///
+/// # Returns
+///
+/// * `Vec<Vec<G1>>` - h(x) vectors corresponding to the polynomials
+pub fn compute_h_parallel(
+    advice_polys: &[Polynomial<Fp, Coeff>],
+    params: &ParamsKZG<Bn256>,
+    column_range: Range<usize>,
+) -> Vec<Vec<G1>> {
+    advice_polys[column_range]
+        // Parallelize the independent amortized openings of the user ID and balance polynomials
+        .par_iter()
+        .map(|poly| compute_h(params, poly))
+        .collect()
+}
+
+/// Calculate all opening proofs at once for the polynomials using the amortized KZG approach
+///
+/// # Arguments
+///
+/// * `h_vectors` - the h(X) vectors calculated for the polynomials using the amortized KZG approach
 /// * `omega` - $\omega$, the generator of the multiplicative subgroup used to interpolate the polynomials.
 ///
 /// # Returns
 ///
 /// * `Vec<Vec<G1>>` - all KZG opening proofs for the polynomials in the range
-pub fn open_user_points_amortized(
-    advice_polys: &[Polynomial<Fp, Coeff>],
-    params: &ParamsKZG<Bn256>,
-    column_range: Range<usize>,
-    omega: Fp,
-) -> Vec<Vec<G1>> {
-    advice_polys[column_range]
+pub fn open_all_user_points_amortized(h_vectors: &[&[G1]], omega: Fp) -> Vec<Vec<G1>> {
+    h_vectors
         // Parallelize the independent amortized openings of the user ID and balance polynomials
         .par_iter()
-        .map(|poly| {
-            let mut h = compute_h(params, poly);
-            best_fft(&mut h, omega, poly.len().trailing_zeros());
+        .map(|h_vector| {
+            let mut h: Vec<G1> = (*h_vector).to_vec();
+            best_fft(&mut h, omega, h_vector.len().trailing_zeros());
             h
         })
         .collect()
+}
+
+pub fn open_single_user_point_amortized(
+    h_vectors: &[&[G1]],
+    params: &ParamsKZG<Bn256>,
+    challenge: Fp,
+) -> Vec<G1> {
+    let mut challenge_powers = vec![Fp::one(); params.n() as usize];
+    {
+        parallelize(&mut challenge_powers, |o, start| {
+            let mut cur = challenge.pow_vartime([start as u64]);
+            for v in o.iter_mut() {
+                *v = cur;
+                cur *= &challenge;
+            }
+        })
+    }
+    // Convert the h vectors to affine form and calculate the opening proofs
+    h_vectors
+        .par_iter()
+        .map(|h_vector| {
+            let h_affine = (*h_vector)
+                .par_iter()
+                .map(G1::to_affine)
+                .collect::<Vec<_>>();
+            best_multiexp(&challenge_powers, &h_affine)
+        })
+        .collect::<Vec<_>>()
 }
 
 /// Verifies the univariate polynomial grand sum openings


### PR DESCRIPTION
Preliminary benchmark results (with small K and no range check): GWC is better than SHPLONK, but batched amortized opening per user is still much better than GWC. Surprisingly, single amortized opening is even worse than SHPLONK. Verdict: amortized approach is most useful when the goal is to calculate all user openings at once. If it's still not feasible (e.g., for large K), it is better to use the GWC.