### PR TITLE
Created dummy entry generator for benchmark

### DIFF
--- a/kzg_prover/benches/kzg.rs
+++ b/kzg_prover/benches/kzg.rs
@@ -20,7 +20,7 @@ use summa_solvency::{
     },
     cryptocurrency::Cryptocurrency,
     entry::Entry,
-    utils::{big_uint_to_fp, parse_csv_to_entries},
+    utils::{big_uint_to_fp, generate_dummy_entries},
 };
 
 fn bench_kzg<
@@ -31,7 +31,6 @@ fn bench_kzg<
     CONFIG: CircuitConfig<N_CURRENCIES, N_USERS>,
 >(
     name: &str,
-    csv_path: &str,
 ) where
     [(); N_CURRENCIES + 1]:,
 {
@@ -59,7 +58,7 @@ fn bench_kzg<
 
     let mut entries: Vec<Entry<N_CURRENCIES>> = vec![Entry::init_empty(); N_USERS];
     let mut cryptos = vec![Cryptocurrency::init_empty(); N_CURRENCIES];
-    parse_csv_to_entries::<&str, N_CURRENCIES>(csv_path, &mut entries, &mut cryptos).unwrap();
+    let _ = generate_dummy_entries(&mut entries, &mut cryptos);
 
     // Calculate total for all entry columns
     let mut csv_total: Vec<BigUint> = vec![BigUint::from(0u32); N_CURRENCIES];
@@ -261,75 +260,65 @@ fn bench_kzg<
 }
 
 fn criterion_benchmark(_c: &mut Criterion) {
-    const N_CURRENCIES: usize = 2;
-    const N_POINTS: usize = 3;
+    const N_CURRENCIES: usize = 1;
+    const N_POINTS: usize = 2;
 
     // Demonstrating that a higher value of K has a more significant impact on benchmark performance than the number of users
     #[cfg(not(feature = "no_range_check"))]
     {
         const K: u32 = 18;
-        const N_USERS: usize = 16;
+        const N_USERS: usize = (1 << 17) + (1 << 16) - 6;
         bench_kzg::<
             K,
             N_USERS,
             N_CURRENCIES,
             N_POINTS,
             UnivariateGrandSumConfig<N_CURRENCIES, N_USERS>,
-        >(
-            format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
-            format!("../csv/entry_{N_USERS}.csv").as_str(),
-        );
+        >(format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str());
     }
     #[cfg(not(feature = "no_range_check"))]
     {
         const K: u32 = 17;
-        const N_USERS: usize = 64;
+        const N_USERS: usize = (1 << 16) - 6;
         bench_kzg::<
             K,
             N_USERS,
             N_CURRENCIES,
             N_POINTS,
             UnivariateGrandSumConfig<N_CURRENCIES, N_USERS>,
-        >(
-            format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
-            format!("../csv/entry_{N_USERS}.csv").as_str(),
-        );
+        >(format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str());
     }
     //Use the following benchmarks for quick evaluation/prototyping (no range check)
     #[cfg(feature = "no_range_check")]
     {
         const K: u32 = 9;
-        const N_USERS: usize = 64;
+        const N_USERS: usize = (1 << 9) - 6;
         bench_kzg::<K, N_USERS, N_CURRENCIES, N_POINTS, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
             format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
-            format!("../csv/entry_{N_USERS}.csv").as_str(),
         );
     }
     #[cfg(feature = "no_range_check")]
     {
         const K: u32 = 10;
-        const N_USERS: usize = 64;
+        const N_USERS: usize = (1 << 10) - 6;
         bench_kzg::<K, N_USERS, N_CURRENCIES, N_POINTS, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
             format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
-            format!("../csv/entry_{N_USERS}.csv").as_str(),
         );
     }
     #[cfg(feature = "no_range_check")]
     {
         const K: u32 = 11;
-        const N_USERS: usize = 64;
+        const N_USERS: usize = (1 << 11) - 6;
         bench_kzg::<K, N_USERS, N_CURRENCIES, N_POINTS, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
             format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
-            format!("../csv/entry_{N_USERS}.csv").as_str(),
         );
     }
     #[cfg(feature = "no_range_check")]
     {
         const K: u32 = 12;
-        const N_USERS: usize = 64;
+        const N_USERS: usize = (1 << 12) - 6;
         bench_kzg::<K, N_USERS, N_CURRENCIES, N_POINTS, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
             format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
-            format!("../csv/entry_{N_USERS}.csv").as_str(),
         );
     }
 }

--- a/kzg_prover/src/entry.rs
+++ b/kzg_prover/src/entry.rs
@@ -5,14 +5,14 @@ use crate::utils::big_intify_username;
 /// An entry in the Merkle Sum Tree from the database of the CEX.
 /// It contains the username and the balances of the user.
 #[derive(Clone, Debug)]
-pub struct Entry<const N_ASSETS: usize> {
+pub struct Entry<const N_CURRENCIES: usize> {
     username_as_big_uint: BigUint,
-    balances: [BigUint; N_ASSETS],
+    balances: [BigUint; N_CURRENCIES],
     username: String,
 }
 
-impl<const N_ASSETS: usize> Entry<N_ASSETS> {
-    pub fn new(username: String, balances: [BigUint; N_ASSETS]) -> Result<Self, &'static str> {
+impl<const N_CURRENCIES: usize> Entry<N_CURRENCIES> {
+    pub fn new(username: String, balances: [BigUint; N_CURRENCIES]) -> Result<Self, &'static str> {
         Ok(Entry {
             username_as_big_uint: big_intify_username(&username),
             balances,
@@ -21,7 +21,7 @@ impl<const N_ASSETS: usize> Entry<N_ASSETS> {
     }
 
     pub fn init_empty() -> Self {
-        let empty_balances: [BigUint; N_ASSETS] = std::array::from_fn(|_| BigUint::from(0u32));
+        let empty_balances: [BigUint; N_CURRENCIES] = std::array::from_fn(|_| BigUint::from(0u32));
 
         Entry {
             username_as_big_uint: BigUint::from(0u32),
@@ -30,7 +30,7 @@ impl<const N_ASSETS: usize> Entry<N_ASSETS> {
         }
     }
 
-    pub fn balances(&self) -> &[BigUint; N_ASSETS] {
+    pub fn balances(&self) -> &[BigUint; N_CURRENCIES] {
         &self.balances
     }
 

--- a/kzg_prover/src/utils/csv_parser.rs
+++ b/kzg_prover/src/utils/csv_parser.rs
@@ -7,9 +7,9 @@ use std::path::Path;
 use crate::cryptocurrency::Cryptocurrency;
 use crate::entry::Entry;
 
-pub fn parse_csv_to_entries<P: AsRef<Path>, const N_ASSETS: usize>(
+pub fn parse_csv_to_entries<P: AsRef<Path>, const N_CURRENCIES: usize>(
     path: P,
-    entries: &mut [Entry<N_ASSETS>],
+    entries: &mut [Entry<N_CURRENCIES>],
     cryptocurrencies: &mut [Cryptocurrency],
 ) -> Result<(), Box<dyn Error>> {
     let file = File::open(path)?;
@@ -39,7 +39,7 @@ pub fn parse_csv_to_entries<P: AsRef<Path>, const N_ASSETS: usize>(
         }
     }
 
-    let mut balances_acc: Vec<BigUint> = vec![BigUint::from(0_usize); N_ASSETS];
+    let mut balances_acc: Vec<BigUint> = vec![BigUint::from(0_usize); N_CURRENCIES];
 
     for (i, result) in rdr.deserialize().enumerate() {
         let record: HashMap<String, String> = result?;

--- a/kzg_prover/src/utils/dummy_entries.rs
+++ b/kzg_prover/src/utils/dummy_entries.rs
@@ -7,18 +7,18 @@ use crate::cryptocurrency::Cryptocurrency;
 use crate::entry::Entry;
 
 // This is for testing purposes with a large dataset instead of using a CSV file
-pub fn generate_dummy_entries<const N_ASSETS: usize>(
-    entries: &mut [Entry<N_ASSETS>],
+pub fn generate_dummy_entries<const N_CURRENCIES: usize>(
+    entries: &mut [Entry<N_CURRENCIES>],
     cryptocurrencies: &mut [Cryptocurrency],
 ) -> Result<(), Box<dyn Error>> {
-    // Ensure N_ASSETS is greater than 0.
-    if N_ASSETS == 0 {
-        return Err("N_ASSETS must be greater than 0".into());
+    // Ensure N_CURRENCIES is greater than 0.
+    if N_CURRENCIES == 0 {
+        return Err("N_CURRENCIES must be greater than 0".into());
     }
 
-    // Ensure the length of `cryptocurrencies` matches `N_ASSETS`.
-    if cryptocurrencies.len() != N_ASSETS {
-        return Err("cryptocurrencies length must be equal to N_ASSETS".into());
+    // Ensure the length of `cryptocurrencies` matches `N_CURRENCIES`.
+    if cryptocurrencies.len() != N_CURRENCIES {
+        return Err("cryptocurrencies length must be equal to N_CURRENCIES".into());
     }
 
     for (i, cryptocurrency) in cryptocurrencies.iter_mut().enumerate() {
@@ -33,7 +33,7 @@ pub fn generate_dummy_entries<const N_ASSETS: usize>(
 
         let username: String = (0..10).map(|_| rng.sample(Alphanumeric) as char).collect();
 
-        let balances: [BigUint; N_ASSETS] =
+        let balances: [BigUint; N_CURRENCIES] =
             std::array::from_fn(|_| BigUint::from(rng.gen_range(1000..90000) as u32));
 
         *entry = Entry::new(username, balances).expect("Failed to create entry");
@@ -51,46 +51,52 @@ mod tests {
     #[test]
     fn test_generate_random_entries() {
         const N_USERS: usize = 1 << 17;
-        const N_ASSETS: usize = 2;
+        const N_CURRENCIES: usize = 2;
 
         // Setup a buffer for entries and cryptocurrencies
-        let mut entries = vec![Entry::<N_ASSETS>::init_empty(); N_USERS];
-        let mut cryptocurrencies = vec![Cryptocurrency::init_empty(); N_ASSETS];
+        let mut entries = vec![Entry::<N_CURRENCIES>::init_empty(); N_USERS];
+        let mut cryptocurrencies = vec![Cryptocurrency::init_empty(); N_CURRENCIES];
 
         // Attempt to generate random entries
-        assert!(generate_dummy_entries::<N_ASSETS>(&mut entries, &mut cryptocurrencies).is_ok());
+        assert!(
+            generate_dummy_entries::<N_CURRENCIES>(&mut entries, &mut cryptocurrencies).is_ok()
+        );
 
         // Verify that entries are populated
         assert_eq!(entries.len(), N_USERS);
         for entry in entries {
             assert!(!entry.username().is_empty());
-            assert_eq!(entry.balances().len(), N_ASSETS);
+            assert_eq!(entry.balances().len(), N_CURRENCIES);
         }
     }
 
     #[test]
     fn test_asset_not_zero() {
         const N_USERS: usize = 1 << 17;
-        const N_ASSETS: usize = 0;
+        const N_CURRENCIES: usize = 0;
 
         // Setup a buffer for entries and cryptocurrencies
-        let mut entries = vec![Entry::<N_ASSETS>::init_empty(); N_USERS];
-        let mut cryptocurrencies = vec![Cryptocurrency::init_empty(); N_ASSETS];
+        let mut entries = vec![Entry::<N_CURRENCIES>::init_empty(); N_USERS];
+        let mut cryptocurrencies = vec![Cryptocurrency::init_empty(); N_CURRENCIES];
 
-        // `N_ASSETS` is zero, so this should fail
-        assert!(generate_dummy_entries::<N_ASSETS>(&mut entries, &mut cryptocurrencies).is_err());
+        // `N_CURRENCIES` is zero, so this should fail
+        assert!(
+            generate_dummy_entries::<N_CURRENCIES>(&mut entries, &mut cryptocurrencies).is_err()
+        );
     }
 
     #[test]
     fn test_wrong_cryptocurrencies() {
         const N_USERS: usize = 1 << 17;
-        const N_ASSETS: usize = 2;
+        const N_CURRENCIES: usize = 2;
 
         // Setup a buffer for entries and cryptocurrencies
-        let mut entries = vec![Entry::<N_ASSETS>::init_empty(); N_USERS];
-        let mut cryptocurrencies = vec![Cryptocurrency::init_empty(); N_ASSETS + 1];
+        let mut entries = vec![Entry::<N_CURRENCIES>::init_empty(); N_USERS];
+        let mut cryptocurrencies = vec![Cryptocurrency::init_empty(); N_CURRENCIES + 1];
 
-        // `cryptocurrencies` length is not equal to `N_ASSETS`, so this should fail
-        assert!(generate_dummy_entries::<N_ASSETS>(&mut entries, &mut cryptocurrencies).is_err());
+        // `cryptocurrencies` length is not equal to `N_CURRENCIES`, so this should fail
+        assert!(
+            generate_dummy_entries::<N_CURRENCIES>(&mut entries, &mut cryptocurrencies).is_err()
+        );
     }
 }

--- a/kzg_prover/src/utils/dummy_entries.rs
+++ b/kzg_prover/src/utils/dummy_entries.rs
@@ -1,0 +1,96 @@
+use num_bigint::BigUint;
+use rand::{distributions::Alphanumeric, Rng};
+use rayon::prelude::*;
+use std::error::Error;
+
+use crate::cryptocurrency::Cryptocurrency;
+use crate::entry::Entry;
+
+// This is for testing purposes with a large dataset instead of using a CSV file
+pub fn generate_dummy_entries<const N_ASSETS: usize>(
+    entries: &mut [Entry<N_ASSETS>],
+    cryptocurrencies: &mut [Cryptocurrency],
+) -> Result<(), Box<dyn Error>> {
+    // Ensure N_ASSETS is greater than 0.
+    if N_ASSETS == 0 {
+        return Err("N_ASSETS must be greater than 0".into());
+    }
+
+    // Ensure the length of `cryptocurrencies` matches `N_ASSETS`.
+    if cryptocurrencies.len() != N_ASSETS {
+        return Err("cryptocurrencies length must be equal to N_ASSETS".into());
+    }
+
+    for (i, cryptocurrency) in cryptocurrencies.iter_mut().enumerate() {
+        *cryptocurrency = Cryptocurrency {
+            name: format!("ETH{i}"),
+            chain: "ETH".to_string(),
+        };
+    }
+
+    entries.par_iter_mut().for_each(|entry| {
+        let mut rng = rand::thread_rng();
+
+        let username: String = (0..10).map(|_| rng.sample(Alphanumeric) as char).collect();
+
+        let balances: [BigUint; N_ASSETS] =
+            std::array::from_fn(|_| BigUint::from(rng.gen_range(1000..90000) as u32));
+
+        *entry = Entry::new(username, balances).expect("Failed to create entry");
+    });
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cryptocurrency::Cryptocurrency;
+    use crate::entry::Entry;
+
+    #[test]
+    fn test_generate_random_entries() {
+        const N_USERS: usize = 1 << 17;
+        const N_ASSETS: usize = 2;
+
+        // Setup a buffer for entries and cryptocurrencies
+        let mut entries = vec![Entry::<N_ASSETS>::init_empty(); N_USERS];
+        let mut cryptocurrencies = vec![Cryptocurrency::init_empty(); N_ASSETS];
+
+        // Attempt to generate random entries
+        assert!(generate_dummy_entries::<N_ASSETS>(&mut entries, &mut cryptocurrencies).is_ok());
+
+        // Verify that entries are populated
+        assert_eq!(entries.len(), N_USERS);
+        for entry in entries {
+            assert!(!entry.username().is_empty());
+            assert_eq!(entry.balances().len(), N_ASSETS);
+        }
+    }
+
+    #[test]
+    fn test_asset_not_zero() {
+        const N_USERS: usize = 1 << 17;
+        const N_ASSETS: usize = 0;
+
+        // Setup a buffer for entries and cryptocurrencies
+        let mut entries = vec![Entry::<N_ASSETS>::init_empty(); N_USERS];
+        let mut cryptocurrencies = vec![Cryptocurrency::init_empty(); N_ASSETS];
+
+        // `N_ASSETS` is zero, so this should fail
+        assert!(generate_dummy_entries::<N_ASSETS>(&mut entries, &mut cryptocurrencies).is_err());
+    }
+
+    #[test]
+    fn test_wrong_cryptocurrencies() {
+        const N_USERS: usize = 1 << 17;
+        const N_ASSETS: usize = 2;
+
+        // Setup a buffer for entries and cryptocurrencies
+        let mut entries = vec![Entry::<N_ASSETS>::init_empty(); N_USERS];
+        let mut cryptocurrencies = vec![Cryptocurrency::init_empty(); N_ASSETS + 1];
+
+        // `cryptocurrencies` length is not equal to `N_ASSETS`, so this should fail
+        assert!(generate_dummy_entries::<N_ASSETS>(&mut entries, &mut cryptocurrencies).is_err());
+    }
+}

--- a/kzg_prover/src/utils/mod.rs
+++ b/kzg_prover/src/utils/mod.rs
@@ -1,6 +1,8 @@
 pub mod amortized_kzg;
 mod csv_parser;
+mod dummy_entries;
 mod operation_helpers;
 
 pub use csv_parser::parse_csv_to_entries;
+pub use dummy_entries::generate_dummy_entries;
 pub use operation_helpers::*;


### PR DESCRIPTION
- The current benchmark is limited by its capacity to handle polynomials for a relatively small number of users, specifically generating proofs for only 16 or 64 users in its benchmarking code. To address this limitation, it is necessary to dynamically initialize entries based on the specified number of users, `N_USERS`, instead of relying on entry data from a CSV file, which constrains us to a fixed user count.
- Fixed the number of user, `N_USERS` in the benchmark code, `kzg.rs` with maximum number of user within given `K`   
- Also, Replaced `N_ASSETS` to `N_CURRENCIES`