### PR TITLE
Remove the unused N_POINTS generic constant

### DIFF
--- a/backend/examples/summa_solvency_flow.rs
+++ b/backend/examples/summa_solvency_flow.rs
@@ -142,7 +142,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let commitment = summa_contract.commitments(snapshot_time).call().await?;
 
     // Ensure the length of the commitment matches the expected size for the number of points.
-    assert_eq!(commitment.to_vec().len(), 0x40 * (N_CURRENCIES - 1));
+    assert_eq!(commitment.to_vec().len(), 0x40 * (N_CURRENCIES + 1));
 
     // Validate the inclusion proof using the contract verifier.
     let mut verification_result = false;

--- a/backend/examples/summa_solvency_flow.rs
+++ b/backend/examples/summa_solvency_flow.rs
@@ -25,7 +25,6 @@ use summa_solvency::{
 
 const K: u32 = 17;
 const N_CURRENCIES: usize = 2;
-const N_POINTS: usize = N_CURRENCIES + 1;
 const N_USERS: usize = 16;
 const USER_INDEX: usize = 0;
 
@@ -96,7 +95,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Using the `round` instance, the commitment is dispatched to the Summa contract with the `dispatch_commitment` method.
     let timestamp = 1u64;
-    let mut round = Round::<N_CURRENCIES, N_POINTS, N_USERS>::new(
+    let mut round = Round::<N_CURRENCIES, N_USERS>::new(
         &signer,
         zk_snark_proof,
         advice_polys,
@@ -143,7 +142,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let commitment = summa_contract.commitments(snapshot_time).call().await?;
 
     // Ensure the length of the commitment matches the expected size for the number of points.
-    assert_eq!(commitment.to_vec().len(), 0x40 * N_POINTS);
+    assert_eq!(commitment.to_vec().len(), 0x40 * (N_CURRENCIES - 1));
 
     // Validate the inclusion proof using the contract verifier.
     let mut verification_result = false;

--- a/backend/src/apis/round.rs
+++ b/backend/src/apis/round.rs
@@ -45,7 +45,6 @@ impl KZGProof {
 /// # Type Parameters
 ///
 /// * `N_CURRENCIES`: The number of currencies for which solvency is verified in this round.
-/// * `N_POINTS`: The number of points in the `UnivariateGrandSum` circuit, which is `N_CURRENCIES + 1`.
 /// * `N_USERS`: The number of users involved in this round of the protocol.
 ///
 /// These parameters are used for initializing the `UnivariateGrandSum` circuit within the `Snapshot` struct.
@@ -57,14 +56,13 @@ impl KZGProof {
 /// * `snapshot`: A `Snapshot` struct capturing the round's state, including user identities and balances.
 /// * `signer`: A reference to a `SummaSigner`, the entity responsible for signing transactions with the Summa contract in this round.
 ///
-pub struct Round<'a, const N_CURRENCIES: usize, const N_POINTS: usize, const N_USERS: usize> {
+pub struct Round<'a, const N_CURRENCIES: usize, const N_USERS: usize> {
     timestamp: u64,
-    snapshot: Snapshot<N_CURRENCIES, N_POINTS, N_USERS>,
+    snapshot: Snapshot<N_CURRENCIES, N_USERS>,
     signer: &'a SummaSigner,
 }
 
-impl<const N_CURRENCIES: usize, const N_POINTS: usize, const N_USERS: usize>
-    Round<'_, N_CURRENCIES, N_POINTS, N_USERS>
+impl<const N_CURRENCIES: usize, const N_USERS: usize> Round<'_, N_CURRENCIES, N_USERS>
 where
     [usize; N_CURRENCIES + 1]: Sized,
 {
@@ -75,10 +73,10 @@ where
         params: ParamsKZG<Bn256>,
         verifying_key: VerifyingKey<G1Affine>,
         timestamp: u64,
-    ) -> Round<'_, N_CURRENCIES, N_POINTS, N_USERS> {
+    ) -> Round<'_, N_CURRENCIES, N_USERS> {
         Round {
             timestamp,
-            snapshot: Snapshot::<N_CURRENCIES, N_POINTS, N_USERS>::new(
+            snapshot: Snapshot::<N_CURRENCIES, N_USERS>::new(
                 zk_snark_proof,
                 advice_polys,
                 params,
@@ -118,15 +116,14 @@ where
 /// * `params`: The parameters for the KZG commitment scheme.
 /// * `verifying_key`: The verifying key for getting domains, which is used for generating inclusion proofs.
 ///
-pub struct Snapshot<const N_CURRENCIES: usize, const N_POINTS: usize, const N_USERS: usize> {
+pub struct Snapshot<const N_CURRENCIES: usize, const N_USERS: usize> {
     zk_snark_proof: Vec<u8>,
     advice_polys: AdviceSingle<G1Affine, Coeff>,
     params: ParamsKZG<Bn256>,
     verifying_key: VerifyingKey<G1Affine>,
 }
 
-impl<const N_CURRENCIES: usize, const N_POINTS: usize, const N_USERS: usize>
-    Snapshot<N_CURRENCIES, N_POINTS, N_USERS>
+impl<const N_CURRENCIES: usize, const N_USERS: usize> Snapshot<N_CURRENCIES, N_USERS>
 where
     [usize; N_CURRENCIES + 1]: Sized,
 {

--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -150,7 +150,6 @@ mod test {
 
     const K: u32 = 17;
     const N_CURRENCIES: usize = 2;
-    const N_POINTS: usize = N_CURRENCIES + 1;
     const N_USERS: usize = 16;
     const PARAMS_PATH: &str = "../backend/ptau/hermez-raw-17";
 
@@ -210,7 +209,7 @@ mod test {
             &[instances.clone()],
         );
 
-        let mut round_one = Round::<N_CURRENCIES, N_POINTS, N_USERS>::new(
+        let mut round_one = Round::<N_CURRENCIES, N_USERS>::new(
             &signer,
             zk_snark_proof.clone(),
             advice_polys.clone(),
@@ -218,7 +217,7 @@ mod test {
             vk.clone(),
             1,
         );
-        let mut round_two = Round::<N_CURRENCIES, N_POINTS, N_USERS>::new(
+        let mut round_two = Round::<N_CURRENCIES, N_USERS>::new(
             &signer,
             zk_snark_proof,
             advice_polys,
@@ -331,7 +330,7 @@ mod test {
         ));
 
         let snapshot_time = 1u64;
-        let mut round = Round::<N_CURRENCIES, N_POINTS, N_USERS>::new(
+        let mut round = Round::<N_CURRENCIES, N_USERS>::new(
             &signer,
             zk_snark_proof,
             advice_polys,

--- a/kzg_prover/benches/kzg.rs
+++ b/kzg_prover/benches/kzg.rs
@@ -18,8 +18,6 @@ use summa_solvency::{
             verify_user_inclusion,
         },
     },
-    cryptocurrency::Cryptocurrency,
-    entry::Entry,
     utils::{big_uint_to_fp, generate_dummy_entries},
 };
 
@@ -27,7 +25,6 @@ fn bench_kzg<
     const K: u32,
     const N_USERS: usize,
     const N_CURRENCIES: usize,
-    const N_POINTS: usize,
     CONFIG: CircuitConfig<N_CURRENCIES, N_USERS>,
 >(
     name: &str,
@@ -243,7 +240,7 @@ fn bench_kzg<
         b.iter_batched(
             || (column_range.clone(), omega, user_index),
             |(column_range, omega, user_index)| {
-                verify_user_inclusion::<N_POINTS>(
+                verify_user_inclusion(
                     &params,
                     &zk_snark_proof,
                     &openings_batch_proof,
@@ -259,39 +256,30 @@ fn bench_kzg<
 
 fn criterion_benchmark(_c: &mut Criterion) {
     const N_CURRENCIES: usize = 1;
-    const N_POINTS: usize = N_CURRENCIES + 1;
 
     // Demonstrating that a higher value of K has a more significant impact on benchmark performance than the number of users
     #[cfg(not(feature = "no_range_check"))]
     {
         const K: u32 = 17;
         const N_USERS: usize = 2usize.pow(K) + 2usize.pow(16) - 6; // Subtracting 2^16 (reserved for range checks) and 6 (reserved rows) from 2^K.
-        bench_kzg::<
-            K,
-            N_USERS,
-            N_CURRENCIES,
-            N_POINTS,
-            UnivariateGrandSumConfig<N_CURRENCIES, N_USERS>,
-        >(format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str());
+        bench_kzg::<K, N_USERS, N_CURRENCIES, UnivariateGrandSumConfig<N_CURRENCIES, N_USERS>>(
+            format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
+        );
     }
     #[cfg(not(feature = "no_range_check"))]
     {
         const K: u32 = 18;
         const N_USERS: usize = 2usize.pow(K) - 2usize.pow(16) - 6; //  Subtracting 2^16 (reserved for range checks) and 6 (reserved rows) from 2^K.
-        bench_kzg::<
-            K,
-            N_USERS,
-            N_CURRENCIES,
-            N_POINTS,
-            UnivariateGrandSumConfig<N_CURRENCIES, N_USERS>,
-        >(format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str());
+        bench_kzg::<K, N_USERS, N_CURRENCIES, UnivariateGrandSumConfig<N_CURRENCIES, N_USERS>>(
+            format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
+        );
     }
     //Use the following benchmarks for quick evaluation/prototyping (no range check)
     #[cfg(feature = "no_range_check")]
     {
         const K: u32 = 9;
         const N_USERS: usize = 2usize.pow(K) - 6;
-        bench_kzg::<K, N_USERS, N_CURRENCIES, N_POINTS, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
+        bench_kzg::<K, N_USERS, N_CURRENCIES, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
             format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
         );
     }
@@ -299,7 +287,7 @@ fn criterion_benchmark(_c: &mut Criterion) {
     {
         const K: u32 = 10;
         const N_USERS: usize = 2usize.pow(K) - 6;
-        bench_kzg::<K, N_USERS, N_CURRENCIES, N_POINTS, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
+        bench_kzg::<K, N_USERS, N_CURRENCIES, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
             format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
         );
     }
@@ -307,7 +295,7 @@ fn criterion_benchmark(_c: &mut Criterion) {
     {
         const K: u32 = 11;
         const N_USERS: usize = 2usize.pow(K) - 6;
-        bench_kzg::<K, N_USERS, N_CURRENCIES, N_POINTS, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
+        bench_kzg::<K, N_USERS, N_CURRENCIES, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
             format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
         );
     }
@@ -315,7 +303,7 @@ fn criterion_benchmark(_c: &mut Criterion) {
     {
         const K: u32 = 12;
         const N_USERS: usize = 2usize.pow(K) - 6;
-        bench_kzg::<K, N_USERS, N_CURRENCIES, N_POINTS, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
+        bench_kzg::<K, N_USERS, N_CURRENCIES, NoRangeCheckConfig<N_CURRENCIES, N_USERS>>(
             format!("K = {K}, N_USERS = {N_USERS}, N_CURRENCIES = {N_CURRENCIES}").as_str(),
         );
     }

--- a/kzg_prover/bin/gen_commit_and_proofs.rs
+++ b/kzg_prover/bin/gen_commit_and_proofs.rs
@@ -104,7 +104,7 @@ fn main() {
     let poly_length = 1 << u64::from(K);
     let total_balances = csv_total
         .iter()
-        .map(|x| big_uint_to_fp(&(x)) * Fp::from(poly_length).invert().unwrap())
+        .map(|x| big_uint_to_fp(x) * Fp::from(poly_length).invert().unwrap())
         .collect::<Vec<Fp>>();
 
     let mut grand_sums_kzg_proof = Vec::new();
@@ -165,8 +165,8 @@ fn main() {
     let user_values = &entries
         .get(user_index as usize)
         .map(|entry| {
-            std::iter::once(big_uint_to_fp(&(entry.username_as_big_uint())))
-                .chain(entry.balances().iter().map(|x| big_uint_to_fp(x)))
+            std::iter::once(big_uint_to_fp(entry.username_as_big_uint()))
+                .chain(entry.balances().iter().map(big_uint_to_fp))
                 .collect::<Vec<Fp>>()
         })
         .unwrap();

--- a/kzg_prover/src/circuits/tests.rs
+++ b/kzg_prover/src/circuits/tests.rs
@@ -25,7 +25,6 @@ mod test {
 
     const K: u32 = 17;
     const N_CURRENCIES: usize = 2;
-    const N_POINTS: usize = N_CURRENCIES + 1;
     const N_USERS: usize = 16;
 
     #[test]
@@ -239,7 +238,7 @@ mod test {
 
         let column_range = 0..N_CURRENCIES + 1;
         // The Verifier verifies the inclusion of the 4th user entry
-        let (inclusion_verified, id_and_balance_values) = verify_user_inclusion::<N_POINTS>(
+        let (inclusion_verified, id_and_balance_values) = verify_user_inclusion(
             &params,
             &zk_snark_proof,
             &openings_batch_proof,
@@ -314,7 +313,7 @@ mod test {
         // Test failure case with the wrong group generator
         // Slightly modify the generator
         let bad_omega = omega.sub(&Fp::one());
-        let (balances_verified, _) = verify_user_inclusion::<N_CURRENCIES>(
+        let (balances_verified, _) = verify_user_inclusion(
             &params,
             &zk_snark_proof,
             &openings_batch_proof,

--- a/kzg_prover/src/circuits/utils.rs
+++ b/kzg_prover/src/circuits/utils.rs
@@ -365,8 +365,6 @@ pub fn verify_grand_sum_openings<const N_CURRENCIES: usize>(
 /// Verifies the KZG batch proof of the polynomial openings being the evaluations
 /// of the advice polynomials at the point corresponding to the user index
 ///
-/// * `N_POINTS` - the size of the user entry being verified (e.g., 1 ID value + 4 balance values = 5)
-///
 /// # Arguments
 /// * `params` - the KZG parameters
 /// * `zk_snark_proof` - the ZK-SNARK proof of the circuit whose advice columns contain the user entry polynomials
@@ -378,7 +376,7 @@ pub fn verify_grand_sum_openings<const N_CURRENCIES: usize>(
 /// # Returns
 /// * `bool` - whether the user entry openings are verified correctly
 /// * `Vec<BigUint>` - the evaluations of the advice polynomials at the point corresponding to the user index
-pub fn verify_user_inclusion<const N_POINTS: usize>(
+pub fn verify_user_inclusion(
     params: &ParamsKZG<Bn256>,
     zk_snark_proof: &[u8],
     balance_opening_batch_proof: &[u8],


### PR DESCRIPTION
The N_POINTS was originally used in `utils.rs` but got replaced with a range, so it hasn't been used for awhile.