### PR TITLE
delete range_check zs

### DIFF
--- a/zk_prover/src/chips/range/range_check.rs
+++ b/zk_prover/src/chips/range/range_check.rs
@@ -118,8 +118,6 @@ impl<const N_BYTES: usize> RangeCheckChip<N_BYTES> {
                     .map(|x| decompose_fp_to_bytes(x, N_BYTES))
                     .transpose_vec(N_BYTES);
 
-                // Initialize empty vector to store running sum values [z_0, ..., z_W].
-                let mut zs: Vec<AssignedCell<Fp, Fp>> = vec![z_0.clone()];
                 let mut z = z_0;
 
                 // Assign running sum `z_{i+1}` = (z_i - k_i) / (2^8) for i = 0..=N_BYTES - 1.
@@ -141,11 +139,10 @@ impl<const N_BYTES: usize> RangeCheckChip<N_BYTES> {
 
                     // Update `z`.
                     z = z_next;
-                    zs.push(z.clone());
                 }
 
                 // Constrain the final running sum output to be zero.
-                region.constrain_constant(zs[N_BYTES].cell(), Fp::from(0))?;
+                region.constrain_constant(z.cell(), Fp::from(0))?;
 
                 Ok(())
             },


### PR DESCRIPTION
since the `constrain_constant` of `range_check` only needs to verify whether the highest bit of the data is 0, and the bytes have already iterated through `N_BYTES`. I think it is unnecessary to use a separate vec `zs` to store the iteration result of highest bit. We can directly compare the final iteration result `z`