### PR TITLE
Overflow Risk Mitigation in Merkle Sum Trees Using keccak256

### DIFF
--- a/backend/src/tests.rs
+++ b/backend/src/tests.rs
@@ -262,7 +262,7 @@ mod test {
             liability_commitment_logs[0],
             LiabilitiesCommitmentSubmittedFilter {
                 timestamp: U256::from(1),
-                mst_root: "0x18d6ab953235a811edffa4cead74ea045e7cd2085771a2269d59dca054c955b1"
+                mst_root: "0x177bf452ad139f067a64fe09fdc30aae46144d60abfa2ad9f0c70928e29a26d1"
                     .parse()
                     .unwrap(),
                 root_balances: vec![U256::from(556862), U256::from(556862)],

--- a/zk_prover/src/circuits/tests.rs
+++ b/zk_prover/src/circuits/tests.rs
@@ -339,17 +339,17 @@ mod test {
                     cell_values: vec![
                         (
                             ((Any::advice(), 0).into(), 0).into(),
-                            "0xe113acd03b98f0bab0ef6f577245d5d008cbcc19ef2dab3608aa4f37f72a407"
+                            "0x167505f45c4ef4a0b051c30e881d2e8f881f26f5edb231396198a2cc1712f5ad"
                                 .to_string()
                         ),
                         (
                             ((Any::advice(), 0).into(), 1).into(),
-                            "0x17ef9d8ee0e2c8470814651413b71009a607a020214f749687384a7b7a7eb67a"
+                            "0x2c688f624d2bca741a1c2ad1ad2880721fbfd1613bbc5fe3d2ba66eb672e3aab"
                                 .to_string()
                         ),
                         (
                             ((Any::advice(), 1).into(), 0).into(),
-                            "0x17ef9d8ee0e2c8470814651413b71009a607a020214f749687384a7b7a7eb67a"
+                            "0x2c688f624d2bca741a1c2ad1ad2880721fbfd1613bbc5fe3d2ba66eb672e3aab"
                                 .to_string()
                         ),
                         (((Any::advice(), 2).into(), 0).into(), "0x2".to_string()),
@@ -364,17 +364,17 @@ mod test {
                     cell_values: vec![
                         (
                             ((Any::advice(), 0).into(), 0).into(),
-                            "0xe113acd03b98f0bab0ef6f577245d5d008cbcc19ef2dab3608aa4f37f72a407"
+                            "0x167505f45c4ef4a0b051c30e881d2e8f881f26f5edb231396198a2cc1712f5ad"
                                 .to_string()
                         ),
                         (
                             ((Any::advice(), 1).into(), 0).into(),
-                            "0x17ef9d8ee0e2c8470814651413b71009a607a020214f749687384a7b7a7eb67a"
+                            "0x2c688f624d2bca741a1c2ad1ad2880721fbfd1613bbc5fe3d2ba66eb672e3aab"
                                 .to_string()
                         ),
                         (
                             ((Any::advice(), 1).into(), 1).into(),
-                            "0xe113acd03b98f0bab0ef6f577245d5d008cbcc19ef2dab3608aa4f37f72a407"
+                            "0x167505f45c4ef4a0b051c30e881d2e8f881f26f5edb231396198a2cc1712f5ad"
                                 .to_string()
                         ),
                         (((Any::advice(), 2).into(), 0).into(), "0x2".to_string()),


### PR DESCRIPTION
### Problem Statement

@bbresearcher has identified a potential security risk related to overflow in the Merkle sum tree.
This theoretical issue could allow a Prover to generate identical identities for different users under certain conditions, despite having unique usernames.

For example:
- **UserA's Identity**: `0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000002`
- **UserB's Identity**: `0x1`

In scenarios where both users have the same currency amount, a malicious Prover could exploit this flaw to provide the same cryptographic proof to different users.

### Proposed Changes

To address this vulnerability, we propose the following change, as suggested by @alxkzmn :

- **Use of `keccak256` for Hashing Usernames**: Implementing `keccak256` to hash usernames significantly enhances collision resistance. This measure is crucial given the assumption of a global cryptocurrency user base of approximately $2^{30}$.

### Impact on Security

- By utilizing `keccak256`, we greatly reduce the risk of username collision. The probability of two usernames resulting in the same hash is approximately $2^{-195}$, which is exceedingly low.
This ensures that each username has a unique and secure identity within the MST.
- The `hashed_username` utilizes the full 256 bits produced by `keccak256`. However, to meet the requirements of the Poseidon hash function used in subsequent cryptographic processes, this output is subjected to a modulo operation to fit within the finite field (`Fp`) of 254 bits.
 This adjustment effectively reduces the bit length by approximately 2 bits, yet this reduction does not meaningfully impact the overall security.

#### Computational Feasibility

Even with a powerful hashing capability of $2^{30}$ hashes per second, the time required to encounter a duplicate hash result by chance would be about $2.7 \times 10^{21}$ years.
This is calculated using the formula:
$T = \frac{2^{127}}{2^{30}} \text{ seconds} $

where $2^{127}$ is the estimated number of attempts needed to find a collision based on the birthday paradox, highlighting the impracticality of such an event.